### PR TITLE
Updating the JGit library to 4.11.3.201809181037-r

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ sourceCompatibility = '1.7'
 targetCompatibility = '1.7'
 
 dependencies {
-    compile "org.eclipse.jgit:org.eclipse.jgit:3.6.2.201501210735-r" // 4.6.0.201612231935-r
+    compile "org.eclipse.jgit:org.eclipse.jgit:4.11.3.201809181037-r"
     provided "org.fitnesse:fitnesse:20161106"
 
     testCompile "junit:junit:4.12"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.2.0
+version=2.0.0
 group = org.fitnesse.plugins
 archivesBaseName = fitnesse-git-plugin
 


### PR DESCRIPTION
Latest version of fitnesse-git-plugin is using a very old version of org.eclipse.jgit:org.eclipse.jgit library. They have fixed many bugs in this  library, this PR is to update the version of JGit library.