### PR TITLE
Can you please create a new release to address a security vulnerability in jsch <= 0.1.53 ?

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![maven central](https://maven-badges.herokuapp.com/maven-central/org.fitnesse.plugins/fitnesse-git-plugin/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/org.fitnesse.plugins/fitnesse-git-plugin)
 
+As the above badge shows, the latest release is 1.2.0, dating back to February 2017 - can you please crete a new release? See the PR for the reason.
+
 This project is a plugin module for [FitNesse](http://fitnesse.org).
 
 For those of us who fancy a more tight integration with their source control system there is a Git based version controller available. This version controller creates a commit for every page change. The `.RecentChanges` page can also be tailored to show the Git version history, instead of the default file based history.


### PR DESCRIPTION
Hello @amolenaar,

The latest release of fitnesse-git-plugin is v1.2.0, which dates back to February 2017 and depends on a version of jgit that in turn depends on version 0.1.50 of jsch:

```
[INFO] +- org.fitnesse.plugins:fitnesse-git-plugin:jar:1.2.0:compile
[INFO] |  \- org.eclipse.jgit:org.eclipse.jgit:jar:3.6.2.201501210735-r:compile
[INFO] |     +- com.jcraft:jsch:jar:0.1.50:compile

```

Versions of jsch below 0.1.54 suffer from the following security vulnerability: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5725.

I see that 
1) version v4.7.0.201704051617-r of jgit upgraded to version 0.1.54 of jsch - see https://github.com/eclipse/jgit/commit/9b2b49917ee2814987487ddb5dcaf136d4ca5e79#diff-600376dffeb79835ede4a0b285078036
2) in Sep 2018, the plugin was upgraded to version 4.11.3.201809181037-r of jgit - see https://github.com/zemian/fitnesse-git-plugin/commit/04f3a224f7ae04c479600405bed32ec593a96348

So it looks like if a new version of the fitnesse-git-plugin were to be released then it would no longer suffer from that vulnerability.

Could you please release a new version?

Thank you in advance for your help.

Philip Schwarz